### PR TITLE
Consolidated into metanorma/standoc-models; archive as pointer

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,9 @@
-= Metanorma-CSA Models
+# This repository has been consolidated
 
-image:https://github.com/metanorma/metanorma-model-csa/workflows/make/badge.svg["Build Status", link="https://github.com/metanorma/metanorma-model-csa/actions?query=workflow%3Amake"]
+This repository is now part of **[metanorma/standoc-models](https://github.com/metanorma/standoc-models)** — the consolidated monorepo for the Metanorma document models (Basicdoc + Standoc + all flavours), per [metanorma-core#16](https://github.com/metanorma/metanorma-core/issues/16).
 
-This is where we keep the Metanorma-CSA model definitions.
+- Grammar sources and builds live in [`standoc-models/grammars/`](https://github.com/metanorma/standoc-models/tree/main/grammars).
+- This repository's full commit history is preserved there (imported via `git filter-repo --to-subdirectory-filter`).
+- Open issues were transferred to `standoc-models`; this repository's issue and PR history remains readable.
 
-The Metanorma CSA format is an instance of the
-https://github.com/metanorma/metanorma-model-standoc[Metanorma StandardDocument model].
-Details of the general model can be found on its page.
-
-== CSA Document Model
-
-image::images/Csand_NormalDocument.png[]
+This repository is archived read-only. All new work happens in `standoc-models`.


### PR DESCRIPTION
Final change before archival per metanorma/metanorma-core#16 (P4): this repository is consolidated into metanorma/standoc-models (history preserved via filter-repo import; open issues transferred). This README points there; the repository is archived read-only after merge.